### PR TITLE
Create named export files in root

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
       files: ["*.ts", "*.tsx"],
       extends: ["plugin:@foxglove/typescript"],
       parserOptions: {
-        project: "tsconfig.json",
+        project: ["tsconfig.json", "tsconfig.dts.json"],
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "*.js",
+    "*.d.ts"
   ],
   "scripts": {
     "prepack": "tsc -b",

--- a/preloader.d.ts
+++ b/preloader.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/preloader/index.js";

--- a/preloader.js
+++ b/preloader.js
@@ -1,0 +1,1 @@
+export * from "./dist/preloader/index.js";

--- a/renderer.d.ts
+++ b/renderer.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/renderer/index.js";

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,1 @@
+export * from "./dist/renderer/index.js";

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -1,0 +1,9 @@
+// -*- jsonc -*-
+// special tsconfig to allow *.d.ts files to pass lint
+{
+  "extends": "@foxglove/tsconfig/base",
+  "include": ["./*.d.ts"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Typescript doesn't yet support package exports (https://github.com/microsoft/TypeScript/issues/33079).

See: Node [subpath package exports](https://nodejs.org/api/packages.html#packages_subpath_exports) documentation.

To work around this, create files in the package root which can be imported by TypeScript.