### PR TITLE
Default to transfer = false for socket renderers

### DIFF
--- a/src/renderer/TcpSocketRenderer.ts
+++ b/src/renderer/TcpSocketRenderer.ts
@@ -99,7 +99,7 @@ export class TcpSocketRenderer extends EventEmitter<TcpSocketRendererEvents> {
     this._callbacks.clear();
   }
 
-  async write(data: Uint8Array, transfer = true): Promise<void> {
+  async write(data: Uint8Array, transfer = false): Promise<void> {
     return await new Promise((resolve) => {
       const callId = this._nextCallId++;
       this._callbacks.set(callId, () => {

--- a/src/renderer/UdpSocketRenderer.ts
+++ b/src/renderer/UdpSocketRenderer.ts
@@ -131,7 +131,7 @@ export class UdpSocketRenderer extends EventEmitter<UdpSocketRendererEvents> {
     length?: number,
     port?: number,
     address?: string,
-    transfer = true,
+    transfer = false,
   ): Promise<void> {
     return await new Promise((resolve) => {
       const callId = this._nextCallId++;


### PR DESCRIPTION
**Public-Facing Changes**
This changes the default write & send behavior for the TCP and UDP socket renderers.


**Description**
Currently we use the `postMessage` transfer feature to efficiently transfer buffers in our socket renders. This can cause problems downstream when other code tries to reuse those buffers for things like sending to multiple connections. Changing the default behavior to false makes this safer for general use but still gives users the option to transfer if they know their use case supports it.


<!-- link relevant GitHub issues -->
