### PR TITLE
Always set Content-Length header, never use Transfer-Encoding: chunked

### DIFF
--- a/src/shared/HttpTypes.ts
+++ b/src/shared/HttpTypes.ts
@@ -22,9 +22,7 @@ export type HttpResponse = {
   statusMessage?: string;
   headers?: HttpHeaders;
   body?: string;
-  chunkedEncoding?: boolean;
   shouldKeepAlive?: boolean;
-  useChunkedEncodingByDefault?: boolean;
   sendDate?: boolean;
 };
 


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->

- `HttpResponse` options related to chunked encoding have been removed
- HTTP responses will always have the `Content-Length` header set

**Description**
<!-- describe what has changed, and motivation behind those changes -->

We don't support streaming HTTP response bodies across the Electron socket, and many HTTP clients in the wild don't play nicely with Transfer-Encoding: chunked so we always set Content-Length since we have the body length at response time.