### PR TITLE
Add socket to http request

### DIFF
--- a/src/preloader/HttpServerElectron.ts
+++ b/src/preloader/HttpServerElectron.ts
@@ -140,6 +140,9 @@ export class HttpServerElectron {
         rawTrailers: req.rawTrailers,
         method: req.method,
         url: req.url,
+        socket: {
+          localAddress: req.socket.localAddress,
+        },
       };
       this._emit("request", requestId, request);
     });

--- a/src/preloader/HttpServerElectron.ts
+++ b/src/preloader/HttpServerElectron.ts
@@ -142,6 +142,9 @@ export class HttpServerElectron {
         url: req.url,
         socket: {
           localAddress: req.socket.localAddress,
+          localPort: req.socket.localPort,
+          remoteAddress: req.socket.remoteAddress,
+          remotePort: req.socket.remotePort,
         },
       };
       this._emit("request", requestId, request);

--- a/src/shared/HttpTypes.ts
+++ b/src/shared/HttpTypes.ts
@@ -17,6 +17,9 @@ export type HttpRequest = {
   url?: string;
   socket: {
     localAddress: string;
+    localPort: number;
+    remoteAddress?: string;
+    remotePort?: number;
   };
 };
 

--- a/src/shared/HttpTypes.ts
+++ b/src/shared/HttpTypes.ts
@@ -15,6 +15,9 @@ export type HttpRequest = {
   rawTrailers: string[];
   method?: string;
   url?: string;
+  socket: {
+    localAddress: string;
+  };
 };
 
 export type HttpResponse = {


### PR DESCRIPTION
The `socket` field of an http request contains useful properties about the underlying socket for the request. This change exposes the properties for `localAddress`, `localPort`, `remoteAddress`, and `remotePort`.

This allows code handling an http request to lookup these properties. One example use case is identifying which incoming address a request was handled by. Another is identifying the remote source of a request - maybe to track requests from specific sources.